### PR TITLE
Added find function

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ bisect-ppx-report summary
 
 # create html coverage report
 bisect-ppx-report html
+open _coverage/index.html
 ```
 
 ## Usage
@@ -67,11 +68,11 @@ let cll = Cll.init [1; 2; 3; 4; 5; 6];;
   4
 *)
 
-Printf.printf "%i\n" cll.length;;
+Printf.printf "%i\n" (Cll.length cll);;
 (* prints 6 *)
 
-match cll.head with
-| Some node -> Printf.printf "%i\n" node.value
+match (Cll.head cll) with
+| Some value -> Printf.printf "%i\n" value
 | None -> ();;
 (* prints 1 *)
 
@@ -110,7 +111,7 @@ Cll.add cll 7;;
 *)
 
 match Cll.pop cll with
-| Some node -> Printf.printf "%i\n" node
+| Some value -> Printf.printf "%i\n" value
 | None -> ();;
 (* prints 7 *)
 (*
@@ -142,18 +143,33 @@ Cll.to_list cll;;
 
 ## Running examples
 
-### Codewars: Josephus problem
+There aren't many uses I'm aware of for a circular linked list, but I have found two programming puzzles where it's been handy.
+
+### Prerequisites
 
 From the project's root directory:
 
 ```sh
 # intall utop
 $ opam install utop
+```
 
-# install cll dev with opam
-$ opam install .
+### Codewars: Josephus problem
 
+```sh
 # run the josphus_problem.ml toplevel script
-$ utop examples/josephus_problem.ml
+$ dune utop . -- examples/josephus_problem.ml
 4
+```
+
+### Advent of Code 2020 day 23: Crab Cups
+
+By default only part one of this puzzle will run, as part two takes about 40 seconds on my laptop when running with utop.
+
+To enable part two, uncomment the last three lines in `examples/crab_cups.ml`.
+
+```sh
+# run part one of the crab cups toplevel script
+$ dune utop . -- examples/crab_cups.ml
+part one: 67384529
 ```

--- a/examples/crab_cups.ml
+++ b/examples/crab_cups.ml
@@ -1,0 +1,80 @@
+(* https://adventofcode.com/2020/day/23 *)
+
+let parse (cups: string) : int list =
+  cups
+  |> String.to_seq
+  |> List.of_seq
+  |> List.map int_of_char
+  |> List.map (fun x -> x - (int_of_char '0'));;
+
+let pick_up (cups: int Cll.t) : int list =
+  match Cll.pop cups :: Cll.pop cups :: Cll.pop cups :: [] with
+  | [Some a; Some b; Some c] -> [c; b; a]
+  | _ -> assert false;;
+
+let rec insert (cups: int Cll.t) = function
+  | [] -> ()
+  | head :: tail ->
+    Cll.add cups head;
+    insert cups tail;;
+
+let play (turns: int) (cup_list: int list) : int Cll.t =
+  let cups = Cll.init cup_list in
+  let min_cup = List.fold_left min 10 cup_list in
+  let max_cup = List.fold_left max 0 cup_list in
+  let rec seek (n: int) : unit =
+    if n < min_cup then seek max_cup
+    else if Cll.find cups n then ()
+    else seek (n - 1)
+  in
+  let rec recurse (turns: int) : int Cll.t =
+    let start =
+      match Cll.head cups with
+      | None -> assert false
+      | Some n -> n
+    in
+    match turns with
+    | 0 -> cups
+    | _ ->
+      Cll.find cups start |> ignore;
+      Cll.next cups;
+      let picked_up = pick_up cups in
+      seek (start - 1);
+      insert cups picked_up;
+      Cll.find cups start |> ignore;
+      Cll.next cups;
+      recurse (turns - 1)
+  in
+  recurse turns;;
+
+let part_one (cup_list: int list) : int =
+  let cups = play 100 cup_list in
+  Cll.find cups 1 |> ignore;
+  match Cll.to_list cups with
+  | [] -> assert false
+  | _ :: tail ->
+    tail
+    |> List.map string_of_int
+    |> String.concat ""
+    |> int_of_string;;
+
+let[@tail_mod_cons] rec range (start: int) (stop: int) : int list =
+  if start > stop then [] else start :: range (start + 1) stop;;
+
+let part_two (cup_list: int list) : int =
+  let max_cup = List.fold_left max 0 cup_list in
+  let full_cup_list = cup_list @ (range (max_cup + 1) 1_000_000) in
+  let cups = play 10_000_000 full_cup_list in
+  Cll.find cups 1 |> ignore;
+  Cll.next cups;
+  match (Cll.pop cups, Cll.pop cups) with
+  | Some a, Some b -> a * b
+  | _ -> assert false;;
+
+parse "389125467"
+|> part_one
+|> Printf.printf "part one: %i\n%!";;
+
+(* parse "389125467"
+|> part_two
+|> Printf.printf "part two: %i\n";; *)

--- a/examples/josephus_problem.ml
+++ b/examples/josephus_problem.ml
@@ -1,5 +1,3 @@
-#require "cll"
-
 (* https://www.codewars.com/kata/555624b601231dc7a400017a *)
 
 let rec range (start: int) (stop: int) : int list =
@@ -12,7 +10,7 @@ let josephus (n: int) (k: int) : int =
     | 1 ->
       (match Cll.pop cll with
         | None -> assert false
-        | Some value -> if cll.head = None then value else recurse k)
+        | Some value -> if (Cll.head cll) = None then value else recurse k)
     | x when x < 0 -> assert false
     | x ->
       Cll.next cll;

--- a/lib/cll.ml
+++ b/lib/cll.ml
@@ -1,7 +1,24 @@
-type 'a node = { value : 'a; mutable left : 'a node; mutable right : 'a node }
-type 'a cll = { mutable head : 'a node option; mutable length : int }
 
-let add (lst : 'a cll) (elem : 'a) : unit =
+
+type 'a node = {
+  value : 'a;
+  mutable left : 'a node;
+  mutable right : 'a node
+}
+
+type 'a t = {
+  mutable head : 'a node option;
+  mutable length : int;
+  lookup: ('a, 'a node list) Hashtbl.t;
+}
+
+(* type 'a cll = {
+  mutable head : 'a node option;
+  mutable length : int;
+  lookup: ('a, 'a node) Hashtbl.t;
+} *)
+
+let add (lst : 'a t) (elem : 'a) : unit =
   match lst.head with
   | None ->
     let rec first_node = {
@@ -10,7 +27,8 @@ let add (lst : 'a cll) (elem : 'a) : unit =
       right = first_node
     } in
     lst.head <- Some first_node;
-    lst.length <- 1
+    lst.length <- 1;
+    Hashtbl.add lst.lookup elem [first_node]
   | Some head ->
     (* rotate head ccw, insert new node at head *)
     let next = head.right in
@@ -22,30 +40,53 @@ let add (lst : 'a cll) (elem : 'a) : unit =
     head.right <- new_node;
     next.left <- new_node;
     lst.head <- Some new_node;
-    lst.length <- lst.length + 1
+    lst.length <- lst.length + 1;
+    match Hashtbl.find_opt lst.lookup elem with
+    | None -> Hashtbl.add lst.lookup elem [new_node]
+    | Some nodes -> Hashtbl.replace lst.lookup elem (new_node :: nodes)
 
-let pop (lst : 'a cll) : 'a option =
+let pop (lst : 'a t) : 'a option =
+  let pop_node (node: 'a node) : unit =
+    match Hashtbl.find_opt lst.lookup node.value with
+    | None | Some [] -> assert false
+    | Some [_] -> Hashtbl.remove lst.lookup node.value
+    | Some nodes ->
+      nodes
+      |> List.filter (fun n -> not (n == node))
+      |> Hashtbl.replace lst.lookup node.value
+  in
   match lst.head with
   | None -> None
   | Some head when head.left == head ->
     lst.head <- None;
     lst.length <- 0;
+    Hashtbl.remove lst.lookup head.value;
     Some head.value
-  | Some { value; left; right } ->
+  | Some head ->
+    let { value; left; right } = head in
     left.right <- right;
     right.left <- left;
     lst.head <- Some right;
     lst.length <- lst.length - 1;
+    pop_node head;
     Some value
 
-let next (lst : 'a cll) : unit =
-  match lst.head with None -> () | Some head -> lst.head <- Some head.right
+let next (lst : 'a t) : unit =
+  match lst.head with
+  | None -> ()
+  | Some head -> lst.head <- Some head.right
 
-let prev (lst : 'a cll) : unit =
-  match lst.head with None -> () | Some head -> lst.head <- Some head.left
+let prev (lst : 'a t) : unit =
+  match lst.head with
+  | None -> ()
+  | Some head -> lst.head <- Some head.left
 
-let init (lst : 'a list) : 'a cll =
-  let c_list = { head = None; length = 0 } in
+let init (lst : 'a list) : 'a t =
+  let c_list = {
+    head = None;
+    length = 0;
+    lookup = Hashtbl.create 1024
+  } in
   let rec recurse (remaining : 'a list) : unit =
     match remaining with
     | [] -> next c_list
@@ -59,7 +100,7 @@ let init (lst : 'a list) : 'a cll =
     recurse lst;
     c_list
 
-let to_list (lst : 'a cll) : 'a list =
+let to_list (lst : 'a t) : 'a list =
   let rec recurse (start : 'a node) : 'a list =
     match lst.head with
     | None -> [] [@coverage off] (* should never reach here *)
@@ -74,7 +115,15 @@ let to_list (lst : 'a cll) : 'a list =
     next lst;
     head.value :: recurse head
 
-let seek (lst : 'a cll) (value : 'a) : bool =
+let find (lst: 'a t) (value: 'a) : bool =
+  match Hashtbl.find_opt lst.lookup value with
+  | None -> false
+  | Some [] -> assert false
+  | Some (first :: _) ->
+    lst.head <- Some first;
+    true
+
+let seek (lst : 'a t) (value : 'a) : bool =
   let rec recurse (start : 'a node) : bool =
     match lst.head with
     | None -> false [@coverage off] (* should never reach here *)
@@ -90,3 +139,11 @@ let seek (lst : 'a cll) (value : 'a) : bool =
   | Some head ->
     next lst;
     recurse head
+
+let length (lst: 'a t) : int =
+  lst.length
+
+let head (lst: 'a t) : 'a option =
+  match lst.head with
+  | None -> None
+  | Some node -> Some node.value

--- a/lib/cll.ml
+++ b/lib/cll.ml
@@ -1,5 +1,3 @@
-
-
 type 'a node = {
   value : 'a;
   mutable left : 'a node;
@@ -11,12 +9,6 @@ type 'a t = {
   mutable length : int;
   lookup: ('a, 'a node list) Hashtbl.t;
 }
-
-(* type 'a cll = {
-  mutable head : 'a node option;
-  mutable length : int;
-  lookup: ('a, 'a node) Hashtbl.t;
-} *)
 
 let add (lst : 'a t) (elem : 'a) : unit =
   match lst.head with
@@ -48,7 +40,7 @@ let add (lst : 'a t) (elem : 'a) : unit =
 let pop (lst : 'a t) : 'a option =
   let pop_node (node: 'a node) : unit =
     match Hashtbl.find_opt lst.lookup node.value with
-    | None | Some [] -> assert false
+    | None | Some [] -> () [@coverage off] (* should never reach here *)
     | Some [_] -> Hashtbl.remove lst.lookup node.value
     | Some nodes ->
       nodes
@@ -85,7 +77,7 @@ let init (lst : 'a list) : 'a t =
   let c_list = {
     head = None;
     length = 0;
-    lookup = Hashtbl.create 1024
+    lookup = Hashtbl.create 1024;
   } in
   let rec recurse (remaining : 'a list) : unit =
     match remaining with
@@ -118,7 +110,7 @@ let to_list (lst : 'a t) : 'a list =
 let find (lst: 'a t) (value: 'a) : bool =
   match Hashtbl.find_opt lst.lookup value with
   | None -> false
-  | Some [] -> assert false
+  | Some [] -> false [@coverage off] (* should never reach here *)
   | Some (first :: _) ->
     lst.head <- Some first;
     true

--- a/lib/cll.mli
+++ b/lib/cll.mli
@@ -1,14 +1,3 @@
-(* type 'a node = private {
-  value : 'a;
-  mutable left : 'a node;
-  mutable right : 'a node;
-} *)
-
-(* type 'a cll = private {
-  mutable head : 'a node option;
-  mutable length : int
-} *)
-
 type 'a t
 
 val add : 'a t -> 'a -> unit

--- a/lib/cll.mli
+++ b/lib/cll.mli
@@ -1,18 +1,23 @@
-type 'a node = private {
+(* type 'a node = private {
   value : 'a;
   mutable left : 'a node;
   mutable right : 'a node;
-}
+} *)
 
-type 'a cll = private {
+(* type 'a cll = private {
   mutable head : 'a node option;
   mutable length : int
-}
+} *)
 
-val add : 'a cll -> 'a -> unit
-val pop : 'a cll -> 'a option
-val next : 'a cll -> unit
-val prev : 'a cll -> unit
-val init : 'a list -> 'a cll
-val to_list : 'a cll -> 'a list
-val seek : 'a cll -> 'a -> bool
+type 'a t
+
+val add : 'a t -> 'a -> unit
+val pop : 'a t -> 'a option
+val next : 'a t -> unit
+val prev : 'a t -> unit
+val init : 'a list -> 'a t
+val to_list : 'a t -> 'a list
+val find: 'a t -> 'a -> bool
+val seek : 'a t -> 'a -> bool
+val head : 'a t -> 'a option
+val length : 'a t -> int

--- a/test/cll_tests.ml
+++ b/test/cll_tests.ml
@@ -2,15 +2,15 @@ open OUnit2
 
 let create_empty_list _ =
   let cll = Cll.init [] in
-  assert_equal cll.length 0;
-  assert_equal cll.head None
+  assert_equal (Cll.length cll) 0;
+  assert_equal (Cll.head cll) None
 
 let create_init _ =
   let cll = Cll.init [ 1; 2; 3 ] in
-  assert_equal cll.length 3;
-  match cll.head with
+  assert_equal (Cll.length cll) 3;
+  match (Cll.head cll) with
   | None -> assert false
-  | Some n -> assert_equal n.value 1
+  | Some n -> assert_equal n 1
 
 let initialise_tests =
   "initialise" >::: [
@@ -21,25 +21,21 @@ let initialise_tests =
 let add_to_empty _ =
   let cll = Cll.init [] in
   Cll.add cll 1;
-  assert_equal cll.length 1;
-  match cll.head with
+  assert_equal (Cll.length cll) 1;
+  match (Cll.head cll) with
   | None -> assert false
   | Some n ->
-    assert_equal n.value 1;
-    assert_equal n.right.value 1;
-    assert_equal n.left.value 1
+    assert_equal n 1
 
 let add_to_list _ =
   let cll = Cll.init [ 1; 2; 3 ] in
   Cll.add cll 4;
-  assert_equal cll.length 4;
-  match cll.head with
+  assert_equal (Cll.length cll) 4;
+  match (Cll.head cll) with
   | None -> assert false
   | Some n ->
     (* rotate head ccw and insert between old head and right *)
-    assert_equal n.value 4;
-    assert_equal n.right.value 2;
-    assert_equal n.left.value 1
+    assert_equal n 4
 
 let add_multiple _ =
   let cll = Cll.init [] in
@@ -47,13 +43,11 @@ let add_multiple _ =
   Cll.add cll 2;
   Cll.add cll 3;
   Cll.add cll 4;
-  assert_equal cll.length 4;
-  match cll.head with
+  assert_equal (Cll.length cll) 4;
+  match (Cll.head cll) with
   | None -> assert false
   | Some n ->
-    assert_equal n.value 4;
-    assert_equal n.right.value 1;
-    assert_equal n.left.value 3
+    assert_equal n 4
 
 let add_tests =
   "add" >::: [
@@ -65,21 +59,21 @@ let add_tests =
 let pop_from_empty _ =
   let cll = Cll.init [] in
   assert_equal (Cll.pop cll) None;
-  assert_equal cll.head None
+  assert_equal (Cll.head cll) None
 
 let pop_init _ =
   let cll = Cll.init [ 1; 2; 3; 4 ] in
   assert_equal (Cll.pop cll) (Some 1);
-  assert_equal cll.length 3;
-  match cll.head with
+  assert_equal (Cll.length cll) 3;
+  match (Cll.head cll) with
   | None -> assert false
-  | Some n -> assert_equal n.value 2
+  | Some n -> assert_equal n 2
 
 let pop_from_single _ =
   let cll = Cll.init [ 1 ] in
   assert_equal (Cll.pop cll) (Some 1);
-  assert_equal cll.length 0;
-  assert_equal cll.head None
+  assert_equal (Cll.length cll) 0;
+  assert_equal (Cll.head cll) None
 
 let pop_tests =
   "pop" >::: [
@@ -91,18 +85,17 @@ let pop_tests =
 let next_on_empty _ =
   let cll = Cll.init [] in
   Cll.next cll;
-  assert_equal cll.length 0;
-  assert_equal cll.head None
+  assert_equal (Cll.length cll) 0;
+  assert_equal (Cll.head cll) None
 
 let next_on_list _ =
   let cll = Cll.init [ 1; 2; 3; 4 ] in
   Cll.next cll;
-  assert_equal cll.length 4;
-  match cll.head with
+  assert_equal (Cll.length cll) 4;
+  match (Cll.head cll) with
   | None -> assert false
   | Some n ->
-    assert_equal n.value 2;
-    assert_equal n.left.value 1
+    assert_equal n 2
 
 let next_tests =
   "next" >::: [
@@ -113,18 +106,17 @@ let next_tests =
 let prev_on_empty _ =
   let cll = Cll.init [] in
   Cll.prev cll;
-  assert_equal cll.length 0;
-  assert_equal cll.head None
+  assert_equal (Cll.length cll) 0;
+  assert_equal (Cll.head cll) None
 
 let prev_on_list _ =
   let cll = Cll.init [ 1; 2; 3; 4 ] in
   Cll.prev cll;
-  assert_equal cll.length 4;
-  match cll.head with
+  assert_equal (Cll.length cll) 4;
+  match (Cll.head cll) with
   | None -> assert false
   | Some n ->
-    assert_equal n.value 4;
-    assert_equal n.right.value 1
+    assert_equal n 4
 
 let prev_tests =
   "previous" >::: [
@@ -146,6 +138,15 @@ let to_list_tests =
     "from list of ints" >:: to_list_init;
   ]
 
+let find_on_empty _ =
+  let cll = Cll.init [] in
+  assert_equal (Cll.find cll 1) false
+
+let find_tests =
+  "find" >::: [
+    "on empty list" >:: find_on_empty
+  ]
+
 let seek_on_empty _ =
   let cll = Cll.init [] in
   assert_equal (Cll.seek cll 1) false
@@ -153,31 +154,27 @@ let seek_on_empty _ =
 let seek_when_contains_value _ =
   let cll = Cll.init [ 1; 2; 3; 4 ] in
   assert_equal (Cll.seek cll 2) true;
-  assert_equal cll.length 4;
-  match cll.head with
+  assert_equal (Cll.length cll) 4;
+  match (Cll.head cll) with
   | None -> assert false
   | Some n ->
-    assert_equal n.value 2;
-    assert_equal n.left.value 1;
-    assert_equal n.right.value 3
+    assert_equal n 2
 
 let seek_when_doesn't_contain_value _ =
   let cll = Cll.init [ 1; 2; 3; 4 ] in
   assert_equal (Cll.seek cll 5) false;
-  assert_equal cll.length 4;
-  match cll.head with
+  assert_equal (Cll.length cll) 4;
+  match (Cll.head cll) with
   | None -> assert false
   | Some n ->
-    assert_equal n.value 1;
-    assert_equal n.left.value 4;
-    assert_equal n.right.value 2
+    assert_equal n 1
 
 let seek_when_already_at_value _ =
   let cll = Cll.init [ 1; 2; 3; 4 ] in
   assert_equal (Cll.seek cll 1) true;
-  match cll.head with
+  match (Cll.head cll) with
   | None -> assert false
-  | Some n -> assert_equal n.value 1
+  | Some n -> assert_equal n 1
 
 let seek_tests =
   "seek" >::: [
@@ -195,6 +192,7 @@ let tests =
     next_tests;
     prev_tests;
     to_list_tests;
+    find_tests;
     seek_tests;
   ]
 

--- a/test/cll_tests.ml
+++ b/test/cll_tests.ml
@@ -8,9 +8,7 @@ let create_empty_list _ =
 let create_init _ =
   let cll = Cll.init [ 1; 2; 3 ] in
   assert_equal (Cll.length cll) 3;
-  match (Cll.head cll) with
-  | None -> assert false
-  | Some n -> assert_equal n 1
+  assert_equal (Cll.head cll) (Some 1)
 
 let initialise_tests =
   "initialise" >::: [
@@ -22,32 +20,22 @@ let add_to_empty _ =
   let cll = Cll.init [] in
   Cll.add cll 1;
   assert_equal (Cll.length cll) 1;
-  match (Cll.head cll) with
-  | None -> assert false
-  | Some n ->
-    assert_equal n 1
+  assert_equal (Cll.head cll) (Some 1)
 
 let add_to_list _ =
   let cll = Cll.init [ 1; 2; 3 ] in
   Cll.add cll 4;
   assert_equal (Cll.length cll) 4;
-  match (Cll.head cll) with
-  | None -> assert false
-  | Some n ->
-    (* rotate head ccw and insert between old head and right *)
-    assert_equal n 4
+  assert_equal (Cll.head cll) (Some 4)
 
 let add_multiple _ =
   let cll = Cll.init [] in
   Cll.add cll 1;
   Cll.add cll 2;
+  Cll.add cll 2;
   Cll.add cll 3;
-  Cll.add cll 4;
   assert_equal (Cll.length cll) 4;
-  match (Cll.head cll) with
-  | None -> assert false
-  | Some n ->
-    assert_equal n 4
+  assert_equal (Cll.head cll) (Some 3)
 
 let add_tests =
   "add" >::: [
@@ -65,9 +53,7 @@ let pop_init _ =
   let cll = Cll.init [ 1; 2; 3; 4 ] in
   assert_equal (Cll.pop cll) (Some 1);
   assert_equal (Cll.length cll) 3;
-  match (Cll.head cll) with
-  | None -> assert false
-  | Some n -> assert_equal n 2
+  assert_equal (Cll.head cll) (Some 2)
 
 let pop_from_single _ =
   let cll = Cll.init [ 1 ] in
@@ -75,11 +61,20 @@ let pop_from_single _ =
   assert_equal (Cll.length cll) 0;
   assert_equal (Cll.head cll) None
 
+let pop_all _ =
+  let cll = Cll.init [ 1; 2; 2; 3 ] in
+  assert_equal (Cll.pop cll) (Some 1);
+  assert_equal (Cll.pop cll) (Some 2);
+  assert_equal (Cll.pop cll) (Some 2);
+  assert_equal (Cll.pop cll) (Some 3);
+  assert_equal (Cll.pop cll) None
+
 let pop_tests =
   "pop" >::: [
     "from empty list" >:: pop_from_empty;
     "from list of ints" >:: pop_init;
     "from list with single value" >:: pop_from_single;
+    "all from list" >:: pop_all;
   ]
 
 let next_on_empty _ =
@@ -142,9 +137,27 @@ let find_on_empty _ =
   let cll = Cll.init [] in
   assert_equal (Cll.find cll 1) false
 
+let find_in_list _ =
+  let cll = Cll.init [ 1; 2; 3; 4 ] in
+  assert_equal (Cll.find cll 3) true;
+  assert_equal (Cll.head cll) (Some 3)
+
+let find_in_repeating_list _ =
+  let cll = Cll.init [ 1; 2; 2; 3 ] in
+  assert_equal (Cll.find cll 2) true;
+  assert_equal (Cll.head cll) (Some 2)
+
+let find_when_not_in_list _ =
+  let cll = Cll.init [ 1; 2; 3; 4 ] in
+  assert_equal (Cll.find cll 5) false;
+  assert_equal (Cll.head cll) (Some 1)
+
 let find_tests =
   "find" >::: [
-    "on empty list" >:: find_on_empty
+    "on empty list" >:: find_on_empty;
+    "in list of ints" >:: find_in_list;
+    "in list with repeating values" >:: find_in_repeating_list;
+    "when value not in list" >:: find_when_not_in_list;
   ]
 
 let seek_on_empty _ =


### PR DESCRIPTION
Added `find` function to skip to a value in the linked list using an internal hash table. This means that finding/seeking a value in the list can be performed in near-constant time rather than `O(n)` time.

`seek` still exists to cycle through the list one entry at a time. This may be useful for cases where there are multiple nodes with the same value and it is desirable to find the first occurance of that value.

Changed the interface so that internal records are no longer exposed to the user; all operations are performed on a list by calling functions in the `Cll` module.

`Cll.head` and `Cll.pop` now return option values rather than nodes, e.g. `Some 10` rather than `Some node` where `node.value` is 10.

